### PR TITLE
Add Docker Compose and fix Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,12 +1,7 @@
 FROM golang:1.21-alpine AS builder
 WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-RUN go mod verify
-
-COPY . .
-
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-WORKDIR /root/
-CMD ["go", "run", "main.go"]
+COPY . /app
+RUN go mod download && go mod verify
+RUN cd /app && go build -o backend
+EXPOSE 9000
+ENTRYPOINT ./backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  frontend:
+    build: frontend/.
+    ports:
+      - "8080:8080"
+    environment:
+      - BACKEND_DNS=backend
+      - BACKEND_PORT=9000
+  backend:
+    build: backend/.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,5 +2,5 @@ FROM golang:1.21-alpine AS builder
 WORKDIR /app
 COPY . /app
 RUN go mod download && go mod verify
-RUN cd /app && go build -o goapp
-ENTRYPOINT ./goapp
+RUN cd /app && go build -o frontend
+ENTRYPOINT ./frontend


### PR DESCRIPTION
This pull request updates the Docker setup for both the backend and frontend services, streamlining the build process and improving container configuration. It also introduces a `docker-compose.yml` file to orchestrate both services together.

**Dockerfile and build improvements:**

* Simplified the backend Dockerfile by copying the entire context to `/app`, combining module download and verification steps, building the backend binary, exposing port 9000, and switching to an executable entrypoint instead of running the code directly. (`backend/Dockerfile`)
* Updated the frontend Dockerfile to build the binary as `frontend` (instead of `goapp`) and changed the entrypoint accordingly. (`frontend/Dockerfile`)

**Docker Compose integration:**

* Added a new `docker-compose.yml` file to define and orchestrate `frontend` and `backend` services, including build contexts, port mappings, and environment variables for service communication. (`docker-compose.yml`)