### PR TITLE
Make CI workflow run on pull request too but not image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 env:
   GIT_COMMIT: ${{ github.sha }}

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -37,6 +37,7 @@ jobs:
           path: .
   image:
     name: "Image the application and upload to GitHub Container Registry"
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     needs: [build]
     steps:


### PR DESCRIPTION
This CI workflow will run both on pushes to main and on pull requests to main.
However, it will not run the image job on pull requests